### PR TITLE
Update libchdr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CHDR_SOURCES
   src/libchdr_bitstream.c
   src/libchdr_cdrom.c
   src/libchdr_chd.c
+  src/libchdr_file.c
   src/libchdr_flac.c
   src/libchdr_huffman.c
 )

--- a/include/libchdr/coretypes.h
+++ b/include/libchdr/coretypes.h
@@ -29,6 +29,25 @@ typedef int32_t INT32;
 typedef int16_t INT16;
 typedef int8_t INT8;
 
+struct _core_file
+{
+    UINT64 (*read_function)(void*, void*, UINT64);
+    void (*seek_function)(void*, INT64, int);
+    UINT64 (*tell_function)(void*);
+    void* user_data;
+};
+typedef struct _core_file core_file;
+
+core_file* core_falloc();
+void core_ffree(core_file*);
+
+core_file* core_fopen(const char*);
+void core_fclose(core_file*);
+UINT64 core_fread(core_file*, void*, UINT64);
+void core_fseek(core_file*, INT64, int);
+UINT64 core_ftell(core_file*);
+
+#if 0
 #define core_file FILE
 #define core_fopen(file) fopen(file, "rb")
 #if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__WIN64__)
@@ -46,6 +65,7 @@ typedef int8_t INT8;
 #endif
 #define core_fread(fc, buff, len) fread(buff, 1, len, fc)
 #define core_fclose fclose
+#endif
 
 static UINT64 core_fsize(core_file *f)
 {

--- a/src/libchdr_file.c
+++ b/src/libchdr_file.c
@@ -1,0 +1,45 @@
+#include <libchdr/coretypes.h>
+#include <stdlib.h>
+#include <assert.h>
+
+core_file* core_falloc()
+{
+	core_file* result = calloc(1, sizeof(core_file));
+	return result;
+}
+
+void core_ffree(core_file* file)
+{
+	free(file);
+}
+
+core_file* core_fopen(const char* path)
+{
+	//Not supported
+	assert(0);
+	return NULL;
+}
+
+void core_fclose(core_file* file)
+{
+	//Not supported
+	assert(0);
+}
+
+UINT64 core_fread(core_file* file, void* buffer, UINT64 size)
+{
+	assert(file->read_function != NULL);
+	return file->read_function(file->user_data, buffer, size);
+}
+
+void core_fseek(core_file* file, INT64 position, int whence)
+{
+	assert(file->seek_function != NULL);
+	file->seek_function(file->user_data, position, whence);
+}
+
+UINT64 core_ftell(core_file* file)
+{
+	assert(file->tell_function != NULL);
+	return file->tell_function(file->user_data);
+}


### PR DESCRIPTION
When trying to build Play! I ran into this error.
```
cc1: error: ‘-fno-fat-lto-objects’ are supported only with linker plugin
```
The easiest solution is to update libchdr, so I rebased the `play_integration` branch over the upstream `master` branch.

I did not test anything beyond the build because I do not have any CHD files.

Note I also ran into this issue with pcsx2.

https://github.com/PCSX2/pcsx2/pull/5010
https://github.com/PCSX2/pcsx2/issues/5009

Second attempt at: https://github.com/jpd002/libchdr/pull/1